### PR TITLE
annotation text as label

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -112,10 +112,12 @@ class AnnotationManager:
         return annotations
         
     def refreshAnnotations(self):
+        self.annotations = []
+        self.annotationsName = []
         for annotation in self.getAnnotations():
-            if annotation not in self.annotations:
-                self.annotations.append(annotation)
-                self.annotationsName.append('Annotation')
+            self.annotations.append(annotation)
+            self.annotationsName.append(annotation.document().toPlainText().replace('\n', '\\n'))
+
         i = 0
         to_del = []
         for annotation in self.annotations:


### PR DESCRIPTION
2 changes made.  The first is to use the text of the annotation as the label instead of the generic "Annotation"

The second is that refreshAnnotations() now refreshes all annotations, not just the new ones, so that labels are updated with modified annotation text.  

A side-effect of this is that if you change the label and not the annotation this will be lost on refresh. If I were to fix this I would want to use a dictionary instead of lists for self.annotations and self.annotationsName  so you aren't relying on list order to know which annotation goes with which name.  But this would be a bigger change across the code and i don't know if you want to go in that direction, so I've left this as a small, imperfect request.
